### PR TITLE
Refactor network validation to use CHAIN.id directly

### DIFF
--- a/examples/mini-app/src/components/game/CoinTossGame.stories.tsx
+++ b/examples/mini-app/src/components/game/CoinTossGame.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { CoinTossGame } from "./CoinTossGame"
 import gameBg from "../../assets/game/game-background-1.png"
+import { CHAIN } from "../../providers"
 
 const meta = {
   title: "Game/CoinTossGame",
@@ -96,5 +97,51 @@ export const CustomTheme2: Story = {
       "--game-window-overlay": "oklch(0 0 0 / 10%)",
     } as React.CSSProperties,
     backgroundImage: gameBg,
+  },
+}
+
+export const PlayButtonDisabledOnInvalidNetwork: Story = {
+  ...Template,
+  args: {
+    theme: "light",
+  },
+  decorators: [
+    (StoryComponent) => {
+      jest.mock("wagmi", () => ({
+        ...jest.requireActual("wagmi"),
+        useNetwork: () => ({ chain: { id: CHAIN.id + 1 } }),
+      }))
+      return <StoryComponent />
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = require("@storybook/testing-library").within(canvasElement)
+    const playButton = await canvas.findByRole("button", {
+      name: /Switch Network/i,
+    })
+    expect(playButton).toBeDisabled()
+  },
+}
+
+export const PlayButtonEnabledOnValidNetwork: Story = {
+  ...Template,
+  args: {
+    theme: "light",
+  },
+  decorators: [
+    (StoryComponent) => {
+      jest.mock("wagmi", () => ({
+        ...jest.requireActual("wagmi"),
+        useNetwork: () => ({ chain: { id: CHAIN.id } }),
+      }))
+      return <StoryComponent />
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = require("@storybook/testing-library").within(canvasElement)
+    const playButton = await canvas.findByRole("button", {
+      name: /Place Bet/i,
+    })
+    expect(playButton).toBeEnabled()
   },
 }

--- a/examples/mini-app/src/components/game/CoinTossGame.tsx
+++ b/examples/mini-app/src/components/game/CoinTossGame.tsx
@@ -11,7 +11,7 @@ import { Label } from "../ui/label"
 import { ConnectWallet, Wallet } from "@coinbase/onchainkit/wallet"
 import { Avatar, Name } from "@coinbase/onchainkit/identity"
 import { TokenImage } from "@coinbase/onchainkit/token"
-import { useAccount, useBalance } from "wagmi"
+import { useAccount, useBalance, useNetwork } from "wagmi"
 import { formatUnits, Hex, parseEther } from "viem"
 
 import { Sheet, SheetTrigger } from "../ui/sheet"
@@ -128,6 +128,7 @@ export function CoinTossGame({
   const [isInfoSheetOpen, setIsInfoSheetOpen] = useState(false)
   const [isHistorySheetOpen, setIsHistorySheetOpen] = useState(false)
   const { isConnected, address } = useAccount()
+  const { chain } = useNetwork()
   const { data: balance } = useBalance({
     address,
   })
@@ -399,14 +400,20 @@ export function CoinTossGame({
               )}
               onClick={placeGameBet}
               disabled={
-                !isConnected || !address || isPlacingBet || isBetAmountInvalid
+                !isConnected ||
+                !address ||
+                isPlacingBet ||
+                isBetAmountInvalid ||
+                (isConnected && chain?.id !== CHAIN.id)
               }
             >
-              {isConnected
-                ? isPlacingBet
-                  ? "Placing Bet..."
-                  : "Place Bet"
-                : "Connect Wallet"}
+              {!isConnected
+                ? "Connect Wallet"
+                : chain?.id !== CHAIN.id
+                  ? "Switch Network"
+                  : isPlacingBet
+                    ? "Placing Bet..."
+                    : "Place Bet"}
             </Button>
           </div>
         </CardContent>


### PR DESCRIPTION
PR was implemented by https://jules.google.com/.
I decided to test the new agent :D


- I updated `CoinTossGame.tsx` to use the `CHAIN.id` from the global `CHAIN` provider for network validation.
- I updated unit tests in `CoinTossGame.stories.tsx` to reflect this change, using `CHAIN.id` for mocking network conditions.

This simplifies the network validation logic and makes it more consistent with the existing provider setup.