### PR TITLE
docs: add environment variables and tokens documentation #171

### DIFF
--- a/packages/ui-react/docs/react-guide.md
+++ b/packages/ui-react/docs/react-guide.md
@@ -40,7 +40,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { http, type Hex } from 'viem'
 import { WagmiProvider, createConfig } from 'wagmi'
 import { base } from 'wagmi/chains'
-import { BetSwirlSDKProvider } from '@betswirl/ui'
+import { BetSwirlSDKProvider, type TokenWithImage } from '@betswirl/ui'
 import '@betswirl/ui/styles.css'
 import './index.css'
 import App from './App.tsx'
@@ -59,11 +59,37 @@ const onChainKitConfig: AppConfig = {
   }
 }
 
+// Optional: Define tokens for your application
+const DEGEN_TOKEN: TokenWithImage = {
+  address: "0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed",
+  symbol: "DEGEN",
+  decimals: 18,
+  image: "https://www.betswirl.com/img/tokens/DEGEN.svg"
+}
+
+const ETH_TOKEN: TokenWithImage = {
+  address: "0x0000000000000000000000000000000000000000",
+  symbol: "ETH",
+  decimals: 18,
+  image: "https://www.betswirl.com/img/tokens/ETH.svg"
+}
+
+// Optional: Limit available tokens to specific ones
+const ALLOWED_TOKENS = [
+  DEGEN_TOKEN.address,
+  ETH_TOKEN.address,
+  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC
+]
+
 createRoot(document.getElementById('root')!).render(
   <WagmiProvider config={config}>
     <QueryClientProvider client={queryClient}>
       <OnchainKitProvider chain={base} config={onChainKitConfig}>
-        <BetSwirlSDKProvider initialChainId={base.id}>
+        <BetSwirlSDKProvider
+          initialChainId={base.id}
+          bankrollToken={DEGEN_TOKEN}     // Optional: set default betting token
+          filteredTokens={ALLOWED_TOKENS} // Optional: limit available tokens
+        >
           <App />
         </BetSwirlSDKProvider>
       </OnchainKitProvider>
@@ -118,10 +144,11 @@ git commit -m "Add BetSwirl casino game"
 You can customize the SDK behavior with these optional props:
 
 ```tsx
-<BetSwirlSDKProvider 
+<BetSwirlSDKProvider
   initialChainId={base.id}
   affiliate="0x1234567890123456789012345678901234567890"  // Your affiliate address
   bankrollToken={customToken}                            // Default betting token
+  filteredTokens={["0x...", "0x..."]}                   // Limit available tokens
 >
   <App />
 </BetSwirlSDKProvider>
@@ -129,8 +156,21 @@ You can customize the SDK behavior with these optional props:
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `affiliate` | `string` | Your wallet address to receive affiliate commissions. If not provided, you won't earn commissions |
-| `bankrollToken` | `object` | Default token for betting with address, symbol, decimals, and image. [See available tokens →](./checking-available-tokens.md) |
+| `initialChainId` | `number` | **Required.** Chain ID to initialize the SDK with (currently only Base: 8453) |
+| `affiliate` | `string` | Optional. Your wallet address to receive affiliate commissions. If not provided, default affiliate will be used |
+| `bankrollToken` | `TokenWithImage` | Optional. Default token for betting. Must include `address`, `symbol`, `decimals`, and `image` properties. [See available tokens →](./checking-available-tokens.md) |
+| `filteredTokens` | `string[]` | Optional. Array of token addresses to limit which tokens are available for selection. If not provided, all supported tokens will be available. [Learn more about token filtering →](./checking-available-tokens.md#token-filtering) |
+
+#### TokenWithImage Interface
+
+```tsx
+interface TokenWithImage {
+  address: string      // Token contract address (use "0x0000000000000000000000000000000000000000" for native token)
+  symbol: string       // Token symbol (e.g., "ETH", "DEGEN", "USDC")
+  decimals: number     // Token decimals (18 for most tokens, 6 for USDC)
+  image: string        // URL to token icon image
+}
+```
 
 ### Environment Variables
 
@@ -154,6 +194,68 @@ This library currently supports **Base network only**. The custom RPC URL will b
 **When NOT needed:**
 - For most applications the default RPC works fine
 - If you're just testing or getting started
+
+## Common Issues and Solutions
+
+### TypeScript Errors
+
+**Problem:** `Type 'string' is not assignable to type 'TokenWithImage'`
+
+```tsx
+// ❌ Wrong - missing required properties
+<BetSwirlSDKProvider bankrollToken="DEGEN" />
+
+// ✅ Correct - complete TokenWithImage object
+const DEGEN_TOKEN: TokenWithImage = {
+  address: "0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed",
+  symbol: "DEGEN",
+  decimals: 18,
+  image: "https://www.betswirl.com/img/tokens/DEGEN.svg"
+}
+<BetSwirlSDKProvider bankrollToken={DEGEN_TOKEN} />
+```
+
+**Problem:** `Property 'initialChainId' is missing`
+
+```tsx
+// ❌ Wrong - missing required prop
+<BetSwirlSDKProvider>
+  <App />
+</BetSwirlSDKProvider>
+
+// ✅ Correct - include required initialChainId
+<BetSwirlSDKProvider initialChainId={base.id}>
+  <App />
+</BetSwirlSDKProvider>
+```
+
+### Token Configuration Issues
+
+**Problem:** Token not appearing in the selection list
+
+- Verify the token address is correct and matches the Bank contract
+- Check that `allowed = true` and `paused = false` in the Bank contract
+- Ensure the token is not filtered out by `filteredTokens` prop
+- If using `filteredTokens`, make sure the token address is included in the array
+
+**Problem:** Too many tokens in the selection list
+
+Use `filteredTokens` to limit available options:
+```tsx
+// ✅ Limit to specific tokens for better UX
+<BetSwirlSDKProvider
+  initialChainId={base.id}
+  filteredTokens={["0x0000000000000000000000000000000000000000", "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"]}
+>
+  <App />
+</BetSwirlSDKProvider>
+```
+
+**Problem:** Token icon not displaying
+
+- Verify the `image` URL is accessible and returns a valid image
+- Use the standard BetSwirl token image pattern: `https://www.betswirl.com/img/tokens/{SYMBOL}.svg`
+- Ensure the image URL supports CORS for web applications
 
 ## Example Result
 


### PR DESCRIPTION
This PR addresses issue #171 by documenting environment variables configuration.

## Changes:

- Added clarification that library users don't need .env files
- Documented how to configure affiliate address, tokens via React props
- Created guide for checking available tokens on-chain
- Added optional custom RPC configuration instructions

Library users now understand they configure everything through props, not environment variables.